### PR TITLE
Move LDFLAGS to end

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,8 @@ MK_PATH = $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 VNUM = $(shell $(MK_PATH)/bin/ChIA-PET2 --version | cut -d " " -f 3)
 
 CC=g++
-CFLAGS=-Wall -O2 -Wno-char-subscripts -lz -fopenmp
+CFLAGS=-Wall -O2 -Wno-char-subscripts -fopenmp
+LDFLAGS= -lz
 #CFLAGS=-Wall -Wno-char-subscripts -g -lz -fpermissive
 SOURCES=$(MK_PATH)/src
 BIN=$(MK_PATH)/bin
@@ -39,28 +40,28 @@ endif
 
 ## Build C++ code
 trimLinker: $(SOURCES)/trimLinker.cpp
-	$(CC) $(CFLAGS) -o ${BIN}/$@ ${SOURCES}/trimLinker.cpp
+	$(CC) $(CFLAGS) -o ${BIN}/$@ ${SOURCES}/trimLinker.cpp ${LDFLAGS}
 
 buildBedpe: $(SOURCES)/buildBedpe.cpp
-	$(CC) $(CFLAGS) -o ${BIN}/$@ ${SOURCES}/buildBedpe.cpp
+	$(CC) $(CFLAGS) -o ${BIN}/$@ ${SOURCES}/buildBedpe.cpp ${LDFLAGS}
 
 removeDup: $(SOURCES)/removeDup.cpp
-	$(CC) $(CFLAGS) -o ${BIN}/$@ ${SOURCES}/removeDup.cpp
+	$(CC) $(CFLAGS) -o ${BIN}/$@ ${SOURCES}/removeDup.cpp ${LDFLAGS}
 
 buildTagAlign: $(SOURCES)/buildTagAlign.cpp
-	$(CC) $(CFLAGS) -o ${BIN}/$@ ${SOURCES}/buildTagAlign.cpp
+	$(CC) $(CFLAGS) -o ${BIN}/$@ ${SOURCES}/buildTagAlign.cpp ${LDFLAGS}
 
 tag2Depth: $(SOURCES)/tag2Depth.cpp
-	$(CC) $(CFLAGS) -o ${BIN}/$@ ${SOURCES}/tag2Depth.cpp
+	$(CC) $(CFLAGS) -o ${BIN}/$@ ${SOURCES}/tag2Depth.cpp ${LDFLAGS}
 
 bedpe2Interaction: $(SOURCES)/bedpe2Interaction.cpp
-	$(CC) $(CFLAGS) -o ${BIN}/$@ ${SOURCES}/bedpe2Interaction.cpp
+	$(CC) $(CFLAGS) -o ${BIN}/$@ ${SOURCES}/bedpe2Interaction.cpp ${LDFLAGS}
 
 bedpe2Phased: $(SOURCES)/bedpe2Phased.cpp
-	$(CC) $(CFLAGS) -o ${BIN}/$@ ${SOURCES}/bedpe2Phased.cpp
+	$(CC) $(CFLAGS) -o ${BIN}/$@ ${SOURCES}/bedpe2Phased.cpp ${LDFLAGS}
 
 bedpe2Matrix: $(SOURCES)/bedpe2Matrix.cpp
-	$(CC) -Wall -O2 -std=c++0x -o ${BIN}/$@ ${SOURCES}/bedpe2Matrix.cpp
+	$(CC) -Wall -O2 -std=c++0x -o ${BIN}/$@ ${SOURCES}/bedpe2Matrix.cpp ${LDFLAGS}
 
 ######################################
 ## Create installed version


### PR DESCRIPTION
This PR moves the ordering of the LDFLAGS, in order to solve compilation problems with ZLIB.

For reference, see: 

http://stackoverflow.com/questions/9700414/compilation-problems-with-zlib
http://stackoverflow.com/questions/9145177/undefined-reference-to-gzopen-error

Thanks!  
